### PR TITLE
This commit fixes a `pydantic.ValidationError` that occurred when cre…

### DIFF
--- a/services/summarization_service.py
+++ b/services/summarization_service.py
@@ -126,7 +126,7 @@ def summarize_analysis(
 
     conversation_summary = ConversationSummary(
         is_engaged=full_analysis.conversationState == "ACTIVE_CONVO",
-        date_arc_phase=full_analysis.memory.dateArcPhase,
+        conversation_stage=full_analysis.memory.dateArcPhase,
         topic_heatmap=topic_heatmap,
         liked_topics=liked_topics,
         disliked_topics=[],
@@ -136,6 +136,7 @@ def summarize_analysis(
         has_recent_greeting=not full_analysis.suppressGreeting,
         conversationState=full_analysis.conversationState,
         sexualResponseSuggestion=full_analysis.sexualAnalysis.sexualResponseSuggestion,
+        isGeoRelated=last_message_analysis.isGeoRelated if last_message_analysis else False,
     )
 
     memory_summary = MemorySummary(


### PR DESCRIPTION
…ating the `ConversationSummary` object in `services/summarization_service.py`.

The error was caused by a mismatch between the Pydantic model definition and the parameters being passed during instantiation:
1.  An incorrect keyword argument (`date_arc_phase` instead of `conversation_stage`) was used.
2.  A required field (`isGeoRelated`) was missing from the call.

The fix corrects the keyword argument to `conversation_stage` and adds the missing `isGeoRelated` field, ensuring the data provided matches the model's schema and preventing the validation error.